### PR TITLE
Documentation: Show Coverage Badge in README File

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,46 @@
+name: Android CI with Coverage
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Build with Gradle
+      run: ./gradlew build
+
+    - name: Run Tests with Coverage
+      run: ./gradlew jacocoTestReport
+
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./app/build/reports/jacoco/jacocoTestReport.xml
+        flags: unittests
+        name: codecov-umbrella
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Archive test results
+      uses: actions/upload-artifact@v3
+      with:
+        name: test-results
+        path: app/build/reports/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SMS Logger
 
+[![Code Coverage](https://img.shields.io/badge/Coverage-24%25-yellow.svg)](app/build/reports/jacoco/html/index.html)
+
 A robust Android application that monitors, logs, and tracks all SMS messages on your device in real-time. This app runs as a background service and maintains a comprehensive database of all incoming and outgoing SMS messages with detailed metadata.
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -100,6 +100,21 @@ cd SmsLogger
 
 ## Development
 
+### Code Coverage & Quality
+
+The project uses JaCoCo for code coverage analysis. Current coverage is at 24%, with a goal to increase this over time.
+
+To run coverage analysis locally:
+```bash
+./gradlew jacocoTestReport
+```
+
+The HTML coverage report will be generated at: `app/build/reports/jacoco/html/index.html`
+
+We maintain minimum coverage thresholds to ensure code quality:
+- Current minimum threshold: 24%
+- Target threshold: 80%
+
 ### Development Workflow
 
 We follow a structured branching strategy to ensure clean development and safe releases. Please read our [Contributing Guidelines](CONTRIBUTING.md) for detailed information.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SMS Logger
 
-[![Code Coverage](https://img.shields.io/badge/Coverage-24%25-yellow.svg)](app/build/reports/jacoco/html/index.html)
+[![Code Coverage](https://codecov.io/gh/DanyalTorabi/SmsLogger/branch/main/graph/badge.svg)](https://codecov.io/gh/DanyalTorabi/SmsLogger)
 
 A robust Android application that monitors, logs, and tracks all SMS messages on your device in real-time. This app runs as a background service and maintains a comprehensive database of all incoming and outgoing SMS messages with detailed metadata.
 

--- a/push_changes.sh
+++ b/push_changes.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+set -x
+
+# Navigate to the project directory
+cd /home/danto/AndroidStudioProjects/SmsLogger
+
+# Check git status
+echo "Current git status:"
+git status
+
+# Stage changes
+echo "Staging changes..."
+git add README.md
+git add .github/workflows/android-ci.yml
+
+# Commit changes
+echo "Committing changes..."
+git commit -m "Add code coverage badge and CI workflow - Fixes #25"
+
+# Push changes
+echo "Pushing changes to the repository..."
+git push
+
+echo "Done!"


### PR DESCRIPTION
This PR adds a code coverage badge to the README file and sets up GitHub Actions workflow for automated coverage reporting with Codecov integration. Fixes #25.