### PR TITLE
feat(auth,ui,sync): SMS sync JWT handling, Settings screen, account lockout UI (#53, #54, #55)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,6 +77,9 @@ dependencies {
     // WorkManager - background token expiry checks (#48)
     implementation 'androidx.work:work-runtime-ktx:2.9.0'
 
+    // Preferences - Settings screen (#54)
+    implementation 'androidx.preference:preference-ktx:1.2.1'
+
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -71,6 +71,9 @@ dependencies {
     // WorkManager - background token expiry checks (#48)
     implementation(libs.androidx.work.runtime.ktx)
 
+    // Preferences - Settings screen (#54)
+    implementation(libs.androidx.preference)
+
     testImplementation(libs.junit)
     testImplementation(libs.mockito.core)
     testImplementation(libs.mockito.kotlin)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,6 +47,13 @@
             android:theme="@style/Theme.SmsLogger"
             android:windowSoftInputMode="adjustResize" />
 
+        <!-- Settings Activity (#54) -->
+        <activity
+            android:name=".ui.SettingsActivity"
+            android:exported="false"
+            android:theme="@style/Theme.SmsLogger"
+            android:parentActivityName=".ui.auth.LoginActivity" />
+
         <!-- SMS Logging Service -->
         <service
             android:name=".service.SmsLoggingService"

--- a/app/src/main/java/com/example/smslogger/config/SmsLoggerConfig.kt
+++ b/app/src/main/java/com/example/smslogger/config/SmsLoggerConfig.kt
@@ -51,6 +51,11 @@ class SmsLoggerConfig private constructor(context: Context) {
         get() = prefs.getLong(KEY_SYNC_INTERVAL, DEFAULT_SYNC_INTERVAL)
         set(value) = prefs.edit { putLong(KEY_SYNC_INTERVAL, value) }
 
+    /** Unix timestamp (ms) of the last successful SMS sync batch. 0 if never synced. */
+    var lastSyncTime: Long
+        get() = prefs.getLong(KEY_LAST_SYNC_TIME, 0L)
+        set(value) = prefs.edit { putLong(KEY_LAST_SYNC_TIME, value) }
+
     var batchSize: Int
         get() = prefs.getInt(KEY_BATCH_SIZE, DEFAULT_BATCH_SIZE)
         set(value) = prefs.edit { putInt(KEY_BATCH_SIZE, value) }
@@ -92,6 +97,7 @@ class SmsLoggerConfig private constructor(context: Context) {
         private const val KEY_SYNC_INTERVAL = "sync_interval"
         private const val KEY_BATCH_SIZE = "batch_size"
         private const val KEY_MAX_RETRY_ATTEMPTS = "max_retry_attempts"
+        private const val KEY_LAST_SYNC_TIME = "last_sync_time"
 
         // Defaults
         private const val DEFAULT_SERVER_URL = "http://10.0.2.2:8080"

--- a/app/src/main/java/com/example/smslogger/service/SmsSyncService.kt
+++ b/app/src/main/java/com/example/smslogger/service/SmsSyncService.kt
@@ -20,6 +20,7 @@ import com.example.smslogger.data.AppDatabase
 import com.example.smslogger.data.SmsMessage
 import com.example.smslogger.config.SmsLoggerConfig
 import com.example.smslogger.receiver.SessionExpiredReceiver
+import com.example.smslogger.security.KeystoreCredentialManager
 import com.example.smslogger.security.SessionManager
 import kotlinx.coroutines.*
 import kotlin.math.min
@@ -45,6 +46,7 @@ class SmsSyncService : Service() {
 
     private lateinit var db: AppDatabase
     private lateinit var apiClient: SmsApiClient
+    private lateinit var credentialManager: KeystoreCredentialManager
 
     // Sync configuration
     private var isSyncing = false
@@ -65,6 +67,7 @@ class SmsSyncService : Service() {
     override fun onCreate() {
         super.onCreate()
         db = AppDatabase.getDatabase(applicationContext)
+        credentialManager = KeystoreCredentialManager.getInstance(applicationContext)
 
         // Initialize API client using configured server URL (#49).
         // No username/password needed here – AuthInterceptor injects the stored
@@ -111,7 +114,15 @@ class SmsSyncService : Service() {
             Log.d(TAG, "Starting SMS sync process... (connection attempt ${connectionRetryAttempt + 1})")
 
             try {
-                // Test connection first
+                // ── Auth guard: stop immediately if token is missing/expired (#53) ──
+                if (!credentialManager.isAuthenticated()) {
+                    Log.w(TAG, "Not authenticated – stopping sync service and notifying user")
+                    updateNotification(getString(R.string.error_sync_auth_failed))
+                    stopSelf()
+                    return@launch
+                }
+
+                // Test connectivity to server
                 if (!apiClient.testConnection()) {
                     Log.e(TAG, "Cannot connect to server, will retry later")
                     val nextAttempt = connectionRetryAttempt + 1
@@ -187,13 +198,20 @@ class SmsSyncService : Service() {
                 val apiRequest = smsMessage.toApiRequest()
 
                 if (apiClient.sendSms(apiRequest)) {
-                    // Mark as synced
+                    // Mark as synced and record sync time (#53, #54)
                     val currentTime = System.currentTimeMillis()
                     db.smsDao().markAsSynced(smsMessage.id, currentTime)
+                    SmsLoggerConfig.getInstance(applicationContext).lastSyncTime = currentTime
                     syncedCount++
-
                     Log.d(TAG, "Successfully synced SMS ID: ${smsMessage.id}")
                 } else {
+                    // Check if failure was due to auth (#53) — token may have just expired
+                    if (!credentialManager.isAuthenticated()) {
+                        Log.w(TAG, "Sync failed due to expired/missing token – stopping service")
+                        updateNotification(getString(R.string.error_sync_auth_failed))
+                        stopSelf()
+                        return syncedCount
+                    }
                     Log.w(TAG, "Failed to sync SMS ID: ${smsMessage.id}")
                     break // Stop batch on failure to avoid rate limiting
                 }

--- a/app/src/main/java/com/example/smslogger/ui/SettingsActivity.kt
+++ b/app/src/main/java/com/example/smslogger/ui/SettingsActivity.kt
@@ -1,0 +1,151 @@
+package com.example.smslogger.ui
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.preference.Preference
+import androidx.preference.PreferenceFragmentCompat
+import com.example.smslogger.R
+import com.example.smslogger.config.SmsLoggerConfig
+import com.example.smslogger.data.repository.AuthRepository
+import com.example.smslogger.security.KeystoreCredentialManager
+import com.example.smslogger.service.SmsSyncService
+import com.example.smslogger.ui.auth.LoginActivity
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Settings screen for account and sync management (#54).
+ *
+ * Sections:
+ * - Account: displays logged-in username, logout action
+ * - Sync: last sync time, manual sync trigger
+ * - About: app version, server URL, 2FA info (server-managed)
+ */
+class SettingsActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_settings)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        supportActionBar?.title = getString(R.string.settings_title)
+
+        if (savedInstanceState == null) {
+            supportFragmentManager
+                .beginTransaction()
+                .replace(R.id.settings_container, SettingsFragment())
+                .commit()
+        }
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        onBackPressedDispatcher.onBackPressed()
+        return true
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+
+    class SettingsFragment : PreferenceFragmentCompat() {
+
+        private lateinit var config: SmsLoggerConfig
+        private lateinit var credentialManager: KeystoreCredentialManager
+        private lateinit var authRepository: AuthRepository
+
+        override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+            setPreferencesFromResource(R.xml.preferences, rootKey)
+
+            val ctx = requireContext()
+            config = SmsLoggerConfig.getInstance(ctx)
+            credentialManager = KeystoreCredentialManager.getInstance(ctx)
+            authRepository = AuthRepository(credentialManager, config.serverUrl, ctx)
+
+            populateDynamicPreferences()
+            setupClickListeners()
+        }
+
+        override fun onResume() {
+            super.onResume()
+            // Refresh last sync time every time screen is shown
+            updateLastSyncSummary()
+        }
+
+        // ── Population ────────────────────────────────────────────────────────
+
+        private fun populateDynamicPreferences() {
+            // Username
+            findPreference<Preference>("pref_username")?.summary =
+                credentialManager.getUsername() ?: getString(R.string.pref_username_summary_placeholder)
+
+            // App version
+            val versionName = try {
+                requireContext().packageManager
+                    .getPackageInfo(requireContext().packageName, 0).versionName
+            } catch (_: Exception) { "–" }
+            findPreference<Preference>("pref_app_version")?.summary = versionName
+
+            // Server URL
+            findPreference<Preference>("pref_server_url")?.summary = config.serverUrl
+
+            // Last sync time
+            updateLastSyncSummary()
+        }
+
+        private fun updateLastSyncSummary() {
+            val lastSync = config.lastSyncTime
+            val summary = if (lastSync == 0L) {
+                getString(R.string.pref_last_sync_never)
+            } else {
+                val fmt = SimpleDateFormat("dd MMM yyyy, HH:mm:ss", Locale.getDefault())
+                fmt.format(Date(lastSync))
+            }
+            findPreference<Preference>("pref_last_sync")?.summary = summary
+        }
+
+        // ── Click listeners ───────────────────────────────────────────────────
+
+        private fun setupClickListeners() {
+            // Logout
+            findPreference<Preference>("pref_logout")?.setOnPreferenceClickListener {
+                showLogoutConfirmationDialog()
+                true
+            }
+
+            // Manual sync
+            findPreference<Preference>("pref_sync_now")?.setOnPreferenceClickListener {
+                SmsSyncService.startService(requireContext())
+                findPreference<Preference>("pref_sync_now")?.summary =
+                    getString(R.string.pref_sync_now_started)
+                true
+            }
+        }
+
+        // ── Logout flow ───────────────────────────────────────────────────────
+
+        private fun showLogoutConfirmationDialog() {
+            AlertDialog.Builder(requireContext())
+                .setTitle(getString(R.string.logout_dialog_title))
+                .setMessage(getString(R.string.logout_dialog_message))
+                .setPositiveButton(getString(R.string.logout_dialog_confirm)) { _, _ ->
+                    performLogout()
+                }
+                .setNegativeButton(getString(R.string.logout_dialog_cancel), null)
+                .show()
+        }
+
+        private fun performLogout() {
+            // Clear all data via repository (#54 — "Clear all data on logout")
+            authRepository.logout()
+
+            // Stop sync service
+            SmsSyncService.stopService(requireContext())
+
+            // Navigate back to login
+            val intent = Intent(requireContext(), LoginActivity::class.java)
+            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            startActivity(intent)
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/smslogger/ui/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/example/smslogger/ui/auth/AuthViewModel.kt
@@ -34,10 +34,17 @@ class AuthViewModel(
     // Mutable state for internal use
     private val _authState = MutableStateFlow<AuthState>(AuthState.Initial)
     private val _errorMessage = MutableStateFlow<String?>(null)
+    private val _isLocked = MutableStateFlow(false)
 
     // Public immutable state for UI observation
     val authState: StateFlow<AuthState> = _authState.asStateFlow()
     val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
+
+    /** True when the server has indicated the account is locked (#55). */
+    val isLocked: StateFlow<Boolean> = _isLocked.asStateFlow()
+
+    // Local failed-attempt counter for security event logging (#55)
+    private var failedAttempts = 0
 
     /**
      * Login with username and password
@@ -82,6 +89,8 @@ class AuthViewModel(
             result.fold(
                 onSuccess = { loginResponse ->
                     Log.d(TAG, "Login successful")
+                    failedAttempts = 0
+                    _isLocked.value = false
                     _authState.value = AuthState.Success(
                         loginResponse.user ?: com.example.smslogger.api.UserInfo(
                             id = username, username = username, email = null, createdAt = null
@@ -91,7 +100,10 @@ class AuthViewModel(
                 },
                 onFailure = { throwable ->
                     val userMessage = mapAuthExceptionToMessage(throwable)
-                    Log.w(TAG, "Login failed: ${throwable.javaClass.simpleName}")
+                    failedAttempts++
+                    Log.w(TAG, "Login failed (attempt $failedAttempts): ${throwable.javaClass.simpleName}")
+                    // Track account-locked state for UI (#55)
+                    _isLocked.value = throwable is AccountLockedException
                     _authState.value = AuthState.Error(message = userMessage)
                     _errorMessage.value = userMessage
                 }
@@ -153,6 +165,7 @@ class AuthViewModel(
         if (_authState.value is AuthState.Error) {
             _authState.value = AuthState.Initial
         }
+        _isLocked.value = false
         _errorMessage.value = null
     }
 
@@ -161,6 +174,8 @@ class AuthViewModel(
      */
     fun logout() {
         authRepository.logout()
+        failedAttempts = 0
+        _isLocked.value = false
         _authState.value = AuthState.Initial
         _errorMessage.value = null
         Log.d(TAG, "User logged out")

--- a/app/src/main/java/com/example/smslogger/ui/auth/LoginActivity.kt
+++ b/app/src/main/java/com/example/smslogger/ui/auth/LoginActivity.kt
@@ -198,29 +198,51 @@ class LoginActivity : AppCompatActivity() {
     private fun observeAuthState() {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.authState.collect { state ->
-                    when (state) {
-                        is AuthState.Initial -> {
-                            showLoading(false)
-                            hideError()
+                // Observe primary auth state
+                launch {
+                    viewModel.authState.collect { state ->
+                        when (state) {
+                            is AuthState.Initial -> {
+                                showLoading(false)
+                                hideError()
+                            }
+                            is AuthState.Loading -> {
+                                showLoading(true)
+                                hideError()
+                            }
+                            is AuthState.Success -> {
+                                showLoading(false)
+                                hideError()
+                                onLoginSuccess()
+                            }
+                            is AuthState.Error -> {
+                                showLoading(false)
+                                showError(state.message)
+                                // Clear TOTP on error so user enters a fresh code (#52, #55)
+                                binding.editTextTotp.text?.clear()
+                                // Highlight TOTP field for 2FA-specific errors (#55)
+                                val msg = state.message.lowercase()
+                                if (msg.contains("2fa") || msg.contains("totp") ||
+                                    msg.contains("authenticator") || msg.contains("two-factor")) {
+                                    binding.textInputLayoutTotp.error = state.message
+                                }
+                            }
                         }
-
-                        is AuthState.Loading -> {
-                            showLoading(true)
-                            hideError()
-                        }
-
-                        is AuthState.Success -> {
-                            showLoading(false)
-                            hideError()
-                            onLoginSuccess()
-                        }
-
-                        is AuthState.Error -> {
-                            showLoading(false)
-                            showError(state.message)
-                            // Clear TOTP field on error so user can re-enter a fresh code
-                            binding.editTextTotp.text?.clear()
+                    }
+                }
+                // Observe lockout state: disable login controls when account is locked (#55)
+                launch {
+                    viewModel.isLocked.collect { locked ->
+                        val notLoading = viewModel.authState.value !is AuthState.Loading
+                        binding.buttonLogin.isEnabled = !locked
+                        if (locked) {
+                            binding.editTextUsername.isEnabled = false
+                            binding.editTextPassword.isEnabled = false
+                            binding.editTextTotp.isEnabled = false
+                        } else if (notLoading) {
+                            binding.editTextUsername.isEnabled = true
+                            binding.editTextPassword.isEnabled = true
+                            binding.editTextTotp.isEnabled = true
                         }
                     }
                 }

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/settings_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,6 +36,40 @@
     <string name="totp_help_text">Enter code from Google Authenticator if you have 2FA enabled</string>
     <string name="error_totp_invalid">2FA code must be exactly 6 digits</string>
 
+    <!-- Error messages - account lockout / inactive (#55) -->
+    <string name="error_account_locked">Your account is locked due to multiple failed login attempts. Please try again in 30 minutes.</string>
+    <string name="error_account_inactive">Your account has been deactivated. Please contact administrator.</string>
+    <string name="error_invalid_totp">Invalid 2FA code. Please try again.</string>
+    <string name="error_totp_required">Two-factor authentication code required.</string>
+
+    <!-- Sync auth failure notification (#53) -->
+    <string name="error_sync_auth_failed">Sync paused — please log in again</string>
+
+    <!-- Settings screen (#54) -->
+    <string name="settings_title">Settings</string>
+    <string name="pref_category_account">Account</string>
+    <string name="pref_username_title">Logged in as</string>
+    <string name="pref_username_summary_placeholder">Not logged in</string>
+    <string name="pref_logout_title">Logout</string>
+    <string name="pref_logout_summary">Sign out and clear all data</string>
+    <string name="pref_category_sync">Sync</string>
+    <string name="pref_last_sync_title">Last sync</string>
+    <string name="pref_last_sync_never">Never</string>
+    <string name="pref_sync_now_title">Sync now</string>
+    <string name="pref_sync_now_summary">Manually trigger SMS sync to server</string>
+    <string name="pref_sync_now_started">Sync started…</string>
+    <string name="pref_category_about">About</string>
+    <string name="pref_app_version_title">App version</string>
+    <string name="pref_server_url_title">Server URL</string>
+    <string name="pref_2fa_title">Manage 2FA</string>
+    <string name="pref_2fa_summary">Two-factor authentication is managed on the server. Contact your administrator or visit the server admin panel to enable or disable 2FA for your account.</string>
+
+    <!-- Logout confirmation dialog (#54) -->
+    <string name="logout_dialog_title">Logout</string>
+    <string name="logout_dialog_message">Are you sure you want to logout? All local session data will be cleared.</string>
+    <string name="logout_dialog_confirm">Logout</string>
+    <string name="logout_dialog_cancel">Cancel</string>
+
     <!-- Accessibility -->
     <string name="content_desc_username_field">Username input field</string>
     <string name="content_desc_password_field">Password input field</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <!-- Account Section -->
+    <PreferenceCategory
+        app:title="@string/pref_category_account"
+        app:key="category_account">
+
+        <!-- Logged-in username (read-only display) -->
+        <Preference
+            app:key="pref_username"
+            app:title="@string/pref_username_title"
+            app:summary="@string/pref_username_summary_placeholder"
+            app:selectable="false"
+            app:iconSpaceReserved="false" />
+
+        <!-- Logout -->
+        <Preference
+            app:key="pref_logout"
+            app:title="@string/pref_logout_title"
+            app:summary="@string/pref_logout_summary"
+            app:iconSpaceReserved="false" />
+
+    </PreferenceCategory>
+
+    <!-- Sync Section -->
+    <PreferenceCategory
+        app:title="@string/pref_category_sync"
+        app:key="category_sync">
+
+        <!-- Last sync time (read-only display) -->
+        <Preference
+            app:key="pref_last_sync"
+            app:title="@string/pref_last_sync_title"
+            app:summary="@string/pref_last_sync_never"
+            app:selectable="false"
+            app:iconSpaceReserved="false" />
+
+        <!-- Manual sync trigger -->
+        <Preference
+            app:key="pref_sync_now"
+            app:title="@string/pref_sync_now_title"
+            app:summary="@string/pref_sync_now_summary"
+            app:iconSpaceReserved="false" />
+
+    </PreferenceCategory>
+
+    <!-- About Section -->
+    <PreferenceCategory
+        app:title="@string/pref_category_about"
+        app:key="category_about">
+
+        <!-- App version (read-only) -->
+        <Preference
+            app:key="pref_app_version"
+            app:title="@string/pref_app_version_title"
+            app:selectable="false"
+            app:iconSpaceReserved="false" />
+
+        <!-- Server URL (read-only) -->
+        <Preference
+            app:key="pref_server_url"
+            app:title="@string/pref_server_url_title"
+            app:selectable="false"
+            app:iconSpaceReserved="false" />
+
+        <!-- 2FA info — managed server-side -->
+        <Preference
+            app:key="pref_2fa_info"
+            app:title="@string/pref_2fa_title"
+            app:summary="@string/pref_2fa_summary"
+            app:selectable="false"
+            app:iconSpaceReserved="false" />
+
+    </PreferenceCategory>
+
+</PreferenceScreen>
+

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,79 +1,70 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- Account Section -->
     <PreferenceCategory
-        app:title="@string/pref_category_account"
-        app:key="category_account">
+        android:title="@string/pref_category_account"
+        android:key="category_account">
 
         <!-- Logged-in username (read-only display) -->
         <Preference
-            app:key="pref_username"
-            app:title="@string/pref_username_title"
-            app:summary="@string/pref_username_summary_placeholder"
-            app:selectable="false"
-            app:iconSpaceReserved="false" />
+            android:key="pref_username"
+            android:title="@string/pref_username_title"
+            android:summary="@string/pref_username_summary_placeholder"
+            android:selectable="false" />
 
         <!-- Logout -->
         <Preference
-            app:key="pref_logout"
-            app:title="@string/pref_logout_title"
-            app:summary="@string/pref_logout_summary"
-            app:iconSpaceReserved="false" />
+            android:key="pref_logout"
+            android:title="@string/pref_logout_title"
+            android:summary="@string/pref_logout_summary" />
 
     </PreferenceCategory>
 
     <!-- Sync Section -->
     <PreferenceCategory
-        app:title="@string/pref_category_sync"
-        app:key="category_sync">
+        android:title="@string/pref_category_sync"
+        android:key="category_sync">
 
         <!-- Last sync time (read-only display) -->
         <Preference
-            app:key="pref_last_sync"
-            app:title="@string/pref_last_sync_title"
-            app:summary="@string/pref_last_sync_never"
-            app:selectable="false"
-            app:iconSpaceReserved="false" />
+            android:key="pref_last_sync"
+            android:title="@string/pref_last_sync_title"
+            android:summary="@string/pref_last_sync_never"
+            android:selectable="false" />
 
         <!-- Manual sync trigger -->
         <Preference
-            app:key="pref_sync_now"
-            app:title="@string/pref_sync_now_title"
-            app:summary="@string/pref_sync_now_summary"
-            app:iconSpaceReserved="false" />
+            android:key="pref_sync_now"
+            android:title="@string/pref_sync_now_title"
+            android:summary="@string/pref_sync_now_summary" />
 
     </PreferenceCategory>
 
     <!-- About Section -->
     <PreferenceCategory
-        app:title="@string/pref_category_about"
-        app:key="category_about">
+        android:title="@string/pref_category_about"
+        android:key="category_about">
 
         <!-- App version (read-only) -->
         <Preference
-            app:key="pref_app_version"
-            app:title="@string/pref_app_version_title"
-            app:selectable="false"
-            app:iconSpaceReserved="false" />
+            android:key="pref_app_version"
+            android:title="@string/pref_app_version_title"
+            android:selectable="false" />
 
         <!-- Server URL (read-only) -->
         <Preference
-            app:key="pref_server_url"
-            app:title="@string/pref_server_url_title"
-            app:selectable="false"
-            app:iconSpaceReserved="false" />
+            android:key="pref_server_url"
+            android:title="@string/pref_server_url_title"
+            android:selectable="false" />
 
         <!-- 2FA info — managed server-side -->
         <Preference
-            app:key="pref_2fa_info"
-            app:title="@string/pref_2fa_title"
-            app:summary="@string/pref_2fa_summary"
-            app:selectable="false"
-            app:iconSpaceReserved="false" />
+            android:key="pref_2fa_info"
+            android:title="@string/pref_2fa_title"
+            android:summary="@string/pref_2fa_summary"
+            android:selectable="false" />
 
     </PreferenceCategory>
 
 </PreferenceScreen>
-

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ mockito = "5.7.0"
 mockitoKotlin = "5.1.0"
 lifecycleTesting = "2.7.0"
 workManager = "2.9.0"
+preference = "1.2.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,6 +50,7 @@ mockito-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", versio
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 androidx-lifecycle-runtime-testing = { group = "androidx.lifecycle", name = "lifecycle-runtime-testing", version.ref = "lifecycleTesting" }
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workManager" }
+androidx-preference = { group = "androidx.preference", name = "preference-ktx", version.ref = "preference" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
Implements three tickets from Milestone 4 - API Integration Updates.
---
## #53 — Update SMS Sync to Use JWT Authentication
### Changes to `SmsSyncService.kt`
- **Upfront auth guard** in `startSyncProcess()`: calls `credentialManager.isAuthenticated()` before any network call — stops service immediately if token is missing or expired
- **Auth failure detection** in `performSyncBatch()`: when `sendSms()` returns false, checks if token expired; posts "Sync paused — please log in again" notification and stops service
- **Records `lastSyncTime`** in `SmsLoggerConfig` after each successful message sync (used by #54 settings screen)
### Changes to `SmsLoggerConfig.kt`
- Added `lastSyncTime: Long` preference field (read by SettingsActivity)
---
## #54 — Create Settings Screen for Account Management
### New files
- `res/xml/preferences.xml` — three `PreferenceCategory` sections: Account, Sync, About
- `ui/SettingsActivity.kt` — `PreferenceFragmentCompat` implementation
- `res/layout/activity_settings.xml` — simple `FrameLayout` container
### Features
| Section | Items |
|---------|-------|
| Account | Logged-in username (read-only), Logout with `AlertDialog` confirmation |
| Sync | Last sync time (from `SmsLoggerConfig.lastSyncTime`), Manual sync trigger |
| About | App version, Server URL, 2FA info (server-managed, directs to admin) |
### Build
- Added `androidx.preference-ktx:1.2.1` to `libs.versions.toml` + `build.gradle.kts`
- Registered `SettingsActivity` in `AndroidManifest.xml`
---
## #55 — Handle Account Lockout and Error Messages
### Changes to `AuthViewModel.kt`
- Added `isLocked: StateFlow<Boolean>` — set `true` on `AccountLockedException`, reset on success/clearError/logout
- Added `failedAttempts` counter for local security event logging (no sensitive data)
### Changes to `LoginActivity.kt`
- Observes `isLocked`: disables Login button + all input fields when account is locked
- Highlights `textInputLayoutTotp` error for 2FA-specific error messages
### String resources added
- `error_account_locked`, `error_account_inactive`, `error_invalid_totp`, `error_totp_required`, `error_sync_auth_failed`
---
Closes #53
Closes #54
Closes #55