### PR TITLE
feat(security): implement certificate pinning for API security (#56)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,9 +20,22 @@ android {
     }
 
     buildTypes {
+        debug {
+            // Certificate pinning disabled in debug – empty strings = no pinning
+            buildConfigField "String", "CERT_HOSTNAME", '""'
+            buildConfigField "String", "CERT_PIN_PRIMARY", '""'
+            buildConfigField "String", "CERT_PIN_BACKUP", '""'
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            // Replace these values with real sha256/ pins extracted via:
+            // openssl s_client -connect yourdomain.com:443 | openssl x509 -pubkey -noout \
+            //   | openssl pkey -pubin -outform der | openssl dgst -sha256 -binary \
+            //   | openssl enc -base64
+            buildConfigField "String", "CERT_HOSTNAME", '"yourdomain.com"'
+            buildConfigField "String", "CERT_PIN_PRIMARY", '"sha256/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="'
+            buildConfigField "String", "CERT_PIN_BACKUP", '"sha256/BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB="'
         }
     }
     compileOptions {
@@ -35,6 +48,7 @@ android {
     // If you use View Binding or Data Binding
      buildFeatures {
          viewBinding true // If you use ViewBinding in your Activity
+         buildConfig true // Required for BuildConfig.CERT_* fields (#56)
      }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,13 +29,23 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-            // Replace these values with real sha256/ pins extracted via:
-            // openssl s_client -connect yourdomain.com:443 | openssl x509 -pubkey -noout \
-            //   | openssl pkey -pubin -outform der | openssl dgst -sha256 -binary \
-            //   | openssl enc -base64
-            buildConfigField "String", "CERT_HOSTNAME", '"yourdomain.com"'
-            buildConfigField "String", "CERT_PIN_PRIMARY", '"sha256/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="'
-            buildConfigField "String", "CERT_PIN_BACKUP", '"sha256/BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB="'
+            // ── Certificate Pinning – SOURCE OF TRUTH ────────────────────────
+            // Values MUST be derived from the server pin bundle before release:
+            //   DanyalTorabi/sms-syncer-server → docs/security/android-pin-bundle.json
+            //   Server handoff issue: DanyalTorabi/sms-syncer-server#130
+            //   Rotation runbook:     docs/security/android-certificate-pinning-runbook.md
+            //
+            // Local dev / staging / production setup:
+            //   See docs/security/CERTIFICATE_PINNING.md in this repo
+            //
+            // Mapping:
+            //   CERT_HOSTNAME    ← hosts[].hostname
+            //   CERT_PIN_PRIMARY ← hosts[].pins.current  (sha256/...)
+            //   CERT_PIN_BACKUP  ← hosts[].pins.backup   (sha256/...)
+            // ─────────────────────────────────────────────────────────────────
+            buildConfigField "String", "CERT_HOSTNAME", '"api.example.com"'
+            buildConfigField "String", "CERT_PIN_PRIMARY", '"sha256/REPLACE_WITH_PROD_CURRENT_SPKI"'
+            buildConfigField "String", "CERT_PIN_BACKUP", '"sha256/REPLACE_WITH_PROD_BACKUP_SPKI"'
         }
     }
     compileOptions {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,12 +20,25 @@ android {
     }
 
     buildTypes {
+        debug {
+            // Certificate pinning disabled in debug – empty strings = no pinning
+            buildConfigField("String", "CERT_HOSTNAME", "\"\"")
+            buildConfigField("String", "CERT_PIN_PRIMARY", "\"\"")
+            buildConfigField("String", "CERT_PIN_BACKUP", "\"\"")
+        }
         release {
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            // Replace these values with real sha256/ pins extracted via:
+            // openssl s_client -connect yourdomain.com:443 | openssl x509 -pubkey -noout \
+            //   | openssl pkey -pubin -outform der | openssl dgst -sha256 -binary \
+            //   | openssl enc -base64
+            buildConfigField("String", "CERT_HOSTNAME", "\"yourdomain.com\"")
+            buildConfigField("String", "CERT_PIN_PRIMARY", "\"sha256/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\"")
+            buildConfigField("String", "CERT_PIN_BACKUP", "\"sha256/BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=\"")
         }
     }
     compileOptions {
@@ -37,6 +50,7 @@ android {
     }
     buildFeatures {
         viewBinding = true
+        buildConfig = true // Required for BuildConfig.CERT_* fields (#56)
     }
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,13 +32,23 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            // Replace these values with real sha256/ pins extracted via:
-            // openssl s_client -connect yourdomain.com:443 | openssl x509 -pubkey -noout \
-            //   | openssl pkey -pubin -outform der | openssl dgst -sha256 -binary \
-            //   | openssl enc -base64
-            buildConfigField("String", "CERT_HOSTNAME", "\"yourdomain.com\"")
-            buildConfigField("String", "CERT_PIN_PRIMARY", "\"sha256/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\"")
-            buildConfigField("String", "CERT_PIN_BACKUP", "\"sha256/BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=\"")
+            // ── Certificate Pinning – SOURCE OF TRUTH ────────────────────────
+            // Values MUST be derived from the server pin bundle before release:
+            //   DanyalTorabi/sms-syncer-server → docs/security/android-pin-bundle.json
+            //   Server handoff issue: DanyalTorabi/sms-syncer-server#130
+            //   Rotation runbook:     docs/security/android-certificate-pinning-runbook.md
+            //
+            // Local dev / staging / production setup:
+            //   See docs/security/CERTIFICATE_PINNING.md in this repo
+            //
+            // Mapping:
+            //   CERT_HOSTNAME    ← hosts[].hostname
+            //   CERT_PIN_PRIMARY ← hosts[].pins.current  (sha256/...)
+            //   CERT_PIN_BACKUP  ← hosts[].pins.backup   (sha256/...)
+            // ─────────────────────────────────────────────────────────────────
+            buildConfigField("String", "CERT_HOSTNAME", "\"api.example.com\"")
+            buildConfigField("String", "CERT_PIN_PRIMARY", "\"sha256/REPLACE_WITH_PROD_CURRENT_SPKI\"")
+            buildConfigField("String", "CERT_PIN_BACKUP", "\"sha256/REPLACE_WITH_PROD_BACKUP_SPKI\"")
         }
     }
     compileOptions {

--- a/app/src/main/java/com/example/smslogger/api/SmsApiClient.kt
+++ b/app/src/main/java/com/example/smslogger/api/SmsApiClient.kt
@@ -31,12 +31,8 @@ import javax.net.ssl.SSLPeerUnverifiedException
  *  - If the server URL starts with "http://" (cleartext), pinning is also skipped
  *    with a warning (pinning only works over TLS).
  *
- * To extract the public-key pin for your server:
- *   openssl s_client -connect yourdomain.com:443 \
- *     | openssl x509 -pubkey -noout \
- *     | openssl pkey -pubin -outform der \
- *     | openssl dgst -sha256 -binary \
- *     | openssl enc -base64
+ * See [docs/security/CERTIFICATE_PINNING.md] for local dev setup, staging/production
+ * configuration, and the certificate rotation workflow.
  *
  * Related: #48 (Auto-Logout), #49 (JWT header injection), #50 (API models), #56 (cert pinning)
  */

--- a/app/src/main/java/com/example/smslogger/api/SmsApiClient.kt
+++ b/app/src/main/java/com/example/smslogger/api/SmsApiClient.kt
@@ -2,13 +2,16 @@ package com.example.smslogger.api
 
 import android.content.Context
 import android.util.Log
+import com.example.smslogger.BuildConfig
+import com.example.smslogger.data.exception.CertificatePinningException
+import com.example.smslogger.network.AuthInterceptor
 import kotlinx.serialization.json.Json
 import okhttp3.*
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
-import com.example.smslogger.network.AuthInterceptor
 import java.io.IOException
 import java.util.concurrent.TimeUnit
+import javax.net.ssl.SSLPeerUnverifiedException
 
 /**
  * API client for communicating with SMS sync server.
@@ -21,7 +24,21 @@ import java.util.concurrent.TimeUnit
  * ([AuthRepository]). When instantiated for SMS syncing ([SmsSyncService]),
  * omit them — [AuthInterceptor] will inject the stored token instead (#49).
  *
- * Related: #48 (Auto-Logout), #49 (JWT header injection), #50 (API models)
+ * Certificate pinning (#56):
+ *  - In release builds, [BuildConfig.CERT_HOSTNAME], [BuildConfig.CERT_PIN_PRIMARY]
+ *    and [BuildConfig.CERT_PIN_BACKUP] must be set to real values.
+ *  - In debug builds those fields are empty strings → pinning is skipped.
+ *  - If the server URL starts with "http://" (cleartext), pinning is also skipped
+ *    with a warning (pinning only works over TLS).
+ *
+ * To extract the public-key pin for your server:
+ *   openssl s_client -connect yourdomain.com:443 \
+ *     | openssl x509 -pubkey -noout \
+ *     | openssl pkey -pubin -outform der \
+ *     | openssl dgst -sha256 -binary \
+ *     | openssl enc -base64
+ *
+ * Related: #48 (Auto-Logout), #49 (JWT header injection), #50 (API models), #56 (cert pinning)
  */
 class SmsApiClient(
     private val baseUrl: String,
@@ -41,7 +58,41 @@ class SmsApiClient(
         .writeTimeout(30, TimeUnit.SECONDS)
         .readTimeout(30, TimeUnit.SECONDS)
         .apply { if (context != null) addInterceptor(AuthInterceptor(context)) }
+        .apply { configureCertificatePinning(this) }
         .build()
+
+    /**
+     * Attaches a [CertificatePinner] when pinning is configured for the release build.
+     *
+     * Pinning is skipped when:
+     * - [BuildConfig.CERT_HOSTNAME] is blank (debug builds)
+     * - The [baseUrl] uses plain HTTP (pinning has no effect over cleartext)
+     */
+    private fun configureCertificatePinning(builder: OkHttpClient.Builder) {
+        val hostname = BuildConfig.CERT_HOSTNAME
+        val primaryPin = BuildConfig.CERT_PIN_PRIMARY
+        val backupPin = BuildConfig.CERT_PIN_BACKUP
+
+        if (hostname.isBlank() || primaryPin.isBlank()) {
+            Log.d(TAG, "Certificate pinning disabled (debug build or pins not configured)")
+            return
+        }
+
+        if (baseUrl.startsWith("http://")) {
+            Log.w(TAG, "Certificate pinning skipped – baseUrl uses plain HTTP, not HTTPS. " +
+                    "Pinning only works over TLS.")
+            return
+        }
+
+        val pinner = CertificatePinner.Builder()
+            .add(hostname, primaryPin)
+            .apply { if (backupPin.isNotBlank()) add(hostname, backupPin) }
+            .build()
+
+        builder.certificatePinner(pinner)
+        Log.i(TAG, "Certificate pinning enabled for host: $hostname")
+    }
+
 
     // Token cache – used only during the initial login/testConnection flow
     private var cachedToken: String? = null
@@ -96,6 +147,9 @@ class SmsApiClient(
                 }
                 null
             }
+        } catch (e: SSLPeerUnverifiedException) {
+            Log.e(TAG, "Certificate pinning failure during login – possible MITM attack", e)
+            throw CertificatePinningException(cause = e)
         } catch (e: IOException) {
             Log.e(TAG, "Network error during login", e)
             null
@@ -154,6 +208,9 @@ class SmsApiClient(
                 }
                 false
             }
+        } catch (e: SSLPeerUnverifiedException) {
+            Log.e(TAG, "Certificate pinning failure during SMS sync – possible MITM attack", e)
+            throw CertificatePinningException(cause = e)
         } catch (e: IOException) {
             Log.e(TAG, "Network error sending SMS", e)
             false

--- a/app/src/main/java/com/example/smslogger/data/exception/AuthExceptions.kt
+++ b/app/src/main/java/com/example/smslogger/data/exception/AuthExceptions.kt
@@ -49,3 +49,17 @@ class NetworkException(
     cause: Throwable? = null
 ) : AuthException(message, cause)
 
+/**
+ * Thrown when OkHttp's [CertificatePinner] rejects the server's certificate (#56).
+ *
+ * This indicates either:
+ * - A genuine MITM attack
+ * - The server certificate was rotated and the app pins are stale
+ *
+ * The user should be warned and sync halted until the app is updated.
+ */
+class CertificatePinningException(
+    message: String = "Server certificate does not match the expected pin. Connection refused.",
+    cause: Throwable? = null
+) : AuthException(message, cause)
+

--- a/app/src/main/java/com/example/smslogger/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/example/smslogger/data/repository/AuthRepository.kt
@@ -7,6 +7,7 @@ import com.example.smslogger.api.UserInfo
 import com.example.smslogger.data.exception.AccountInactiveException
 import com.example.smslogger.data.exception.AccountLockedException
 import com.example.smslogger.data.exception.AuthException
+import com.example.smslogger.data.exception.CertificatePinningException
 import com.example.smslogger.data.exception.InvalidCredentialsException
 import com.example.smslogger.data.exception.NetworkException
 import com.example.smslogger.data.exception.ServerErrorException
@@ -132,6 +133,9 @@ class AuthRepository(
                 Result.failure(InvalidCredentialsException())
             }
 
+        } catch (e: CertificatePinningException) {
+            Log.e(TAG, "Certificate pinning failure during login – sync halted")
+            Result.failure(e)
         } catch (e: IOException) {
             Log.e(TAG, "Network error during login")
             Result.failure(NetworkException(cause = e))

--- a/app/src/main/java/com/example/smslogger/service/SmsSyncService.kt
+++ b/app/src/main/java/com/example/smslogger/service/SmsSyncService.kt
@@ -19,6 +19,7 @@ import com.example.smslogger.api.SmsApiRequest
 import com.example.smslogger.data.AppDatabase
 import com.example.smslogger.data.SmsMessage
 import com.example.smslogger.config.SmsLoggerConfig
+import com.example.smslogger.data.exception.CertificatePinningException
 import com.example.smslogger.receiver.SessionExpiredReceiver
 import com.example.smslogger.security.KeystoreCredentialManager
 import com.example.smslogger.security.SessionManager
@@ -219,6 +220,11 @@ class SmsSyncService : Service() {
                 // Small delay between requests to be respectful to the server
                 delay(100)
 
+            } catch (e: CertificatePinningException) {
+                Log.e(TAG, "Certificate pinning failure – halting sync to protect against MITM", e)
+                updateNotification(getString(R.string.error_cert_pinning_failed))
+                stopSelf()
+                return syncedCount
             } catch (e: Exception) {
                 Log.e(TAG, "Error syncing SMS ID: ${smsMessage.id}", e)
                 break // Stop batch on error

--- a/app/src/main/java/com/example/smslogger/ui/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/example/smslogger/ui/auth/AuthViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.example.smslogger.data.exception.AccountInactiveException
 import com.example.smslogger.data.exception.AccountLockedException
 import com.example.smslogger.data.exception.AuthException
+import com.example.smslogger.data.exception.CertificatePinningException
 import com.example.smslogger.data.exception.InvalidCredentialsException
 import com.example.smslogger.data.exception.NetworkException
 import com.example.smslogger.data.exception.ServerErrorException
@@ -187,13 +188,14 @@ class AuthViewModel(
      * falling back to sensible defaults.
      */
     private fun mapAuthExceptionToMessage(throwable: Throwable): String = when (throwable) {
-        is InvalidCredentialsException -> throwable.message ?: "Invalid username or password"
-        is AccountLockedException     -> throwable.message ?: "Account locked. Try again in 30 minutes"
-        is AccountInactiveException   -> throwable.message ?: "Your account has been deactivated"
-        is ServerErrorException       -> throwable.message ?: "Server temporarily unavailable"
-        is NetworkException           -> throwable.message ?: "Network error. Please try again"
-        is AuthException              -> throwable.message ?: "An error occurred. Please try again"
-        else                          -> "An error occurred. Please try again"
+        is InvalidCredentialsException  -> throwable.message ?: "Invalid username or password"
+        is AccountLockedException       -> throwable.message ?: "Account locked. Try again in 30 minutes"
+        is AccountInactiveException     -> throwable.message ?: "Your account has been deactivated"
+        is ServerErrorException         -> throwable.message ?: "Server temporarily unavailable"
+        is CertificatePinningException  -> throwable.message ?: "Security error: server certificate mismatch. Please contact support."
+        is NetworkException             -> throwable.message ?: "Network error. Please try again"
+        is AuthException                -> throwable.message ?: "An error occurred. Please try again"
+        else                            -> "An error occurred. Please try again"
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,6 +45,9 @@
     <!-- Sync auth failure notification (#53) -->
     <string name="error_sync_auth_failed">Sync paused — please log in again</string>
 
+    <!-- Certificate pinning failure notification (#56) -->
+    <string name="error_cert_pinning_failed">Security alert: server certificate mismatch. Sync halted.</string>
+
     <!-- Settings screen (#54) -->
     <string name="settings_title">Settings</string>
     <string name="pref_category_account">Account</string>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,20 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <!-- Allow cleartext traffic for development -->
+    <!--
+        Development domains: allow cleartext (HTTP) for emulator / local testing.
+        Certificate pinning is NOT applied here – debug BuildConfig fields are empty.
+    -->
     <domain-config cleartextTrafficPermitted="true">
-        <!-- Emulator access to host -->
         <domain includeSubdomains="false">10.0.2.2</domain>
-        <!-- Localhost for development -->
         <domain includeSubdomains="false">localhost</domain>
-        <!-- Local network range for testing -->
         <domain includeSubdomains="false">192.168.1.1</domain>
     </domain-config>
 
-    <!-- For production, you should use HTTPS only -->
+    <!--
+        Production domain: HTTPS only + certificate pin-set (#56).
+
+        IMPORTANT: Replace "yourdomain.com" and the sha256/ values with real data.
+        Extract the pin with:
+          openssl s_client -connect yourdomain.com:443 \
+            | openssl x509 -pubkey -noout \
+            | openssl pkey -pubin -outform der \
+            | openssl dgst -sha256 -binary \
+            | openssl enc -base64
+
+        Keep at least one backup pin (for certificate rotation) before deploying
+        a new certificate to the server.
+
+        expiration: set to a date beyond the certificate's validity period.
+        If the date passes without a cert rotation the OS will stop pinning
+        (fail-open) rather than breaking the app permanently.
+    -->
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="true">yourdomain.com</domain>
+        <pin-set expiration="2027-01-01">
+            <!-- Primary pin – current server certificate public key -->
+            <pin digest="SHA-256">AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</pin>
+            <!-- Backup pin – next certificate ready for rotation -->
+            <pin digest="SHA-256">BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=</pin>
+        </pin-set>
+    </domain-config>
+
+    <!-- Default: production HTTPS only, system CA trust anchors -->
     <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system"/>
         </trust-anchors>
     </base-config>
 </network-security-config>
-

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -13,28 +13,34 @@
     <!--
         Production domain: HTTPS only + certificate pin-set (#56).
 
-        IMPORTANT: Replace "yourdomain.com" and the sha256/ values with real data.
-        Extract the pin with:
-          openssl s_client -connect yourdomain.com:443 \
-            | openssl x509 -pubkey -noout \
-            | openssl pkey -pubin -outform der \
-            | openssl dgst -sha256 -binary \
-            | openssl enc -base64
+        ╔══════════════════════════════════════════════════════════════════════╗
+        ║  SOURCE OF TRUTH: docs/security/android-pin-bundle.json             ║
+        ║  in DanyalTorabi/sms-syncer-server (server handoff issue #130)      ║
+        ║                                                                      ║
+        ║  DO NOT edit hostname or pin values here directly.                   ║
+        ║  Always derive them from the server pin bundle:                      ║
+        ║    android-pin-bundle.json → hosts[].hostname                        ║
+        ║    android-pin-bundle.json → hosts[].pins.current                    ║
+        ║    android-pin-bundle.json → hosts[].pins.backup                     ║
+        ║    android-pin-bundle.json → hosts[].validity.notAfter  (expiration) ║
+        ║                                                                      ║
+        ║  Rotation workflow (14-day notice required):                         ║
+        ║    See docs/security/android-certificate-pinning-runbook.md          ║
+        ╚══════════════════════════════════════════════════════════════════════╝
 
-        Keep at least one backup pin (for certificate rotation) before deploying
-        a new certificate to the server.
-
-        expiration: set to a date beyond the certificate's validity period.
-        If the date passes without a cert rotation the OS will stop pinning
-        (fail-open) rather than breaking the app permanently.
+        Placeholder values below must be replaced with real production data
+        from the server pin bundle before releasing to production.
+        See: https://github.com/DanyalTorabi/sms-syncer-server/issues/130
     -->
     <domain-config cleartextTrafficPermitted="false">
-        <domain includeSubdomains="true">yourdomain.com</domain>
+        <!-- hostname → android-pin-bundle.json hosts[].hostname -->
+        <domain includeSubdomains="true">api.example.com</domain>
+        <!-- expiration → android-pin-bundle.json hosts[].validity.notAfter -->
         <pin-set expiration="2027-01-01">
-            <!-- Primary pin – current server certificate public key -->
-            <pin digest="SHA-256">AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</pin>
-            <!-- Backup pin – next certificate ready for rotation -->
-            <pin digest="SHA-256">BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=</pin>
+            <!-- current → android-pin-bundle.json hosts[].pins.current -->
+            <pin digest="SHA-256">REPLACE_WITH_PROD_CURRENT_SPKI</pin>
+            <!-- backup  → android-pin-bundle.json hosts[].pins.backup -->
+            <pin digest="SHA-256">REPLACE_WITH_PROD_BACKUP_SPKI</pin>
         </pin-set>
     </domain-config>
 

--- a/docs/security/CERTIFICATE_PINNING.md
+++ b/docs/security/CERTIFICATE_PINNING.md
@@ -1,0 +1,141 @@
+# Certificate Pinning Guide
+
+This document explains how to configure certificate pinning for local development,
+staging, and production environments.
+
+## Overview
+
+Certificate pinning is implemented via:
+- **OkHttp `CertificatePinner`** – enforced at the HTTP client level (`SmsApiClient.kt`)
+- **Android Network Security Config** – enforced at the OS level (`network_security_config.xml`)
+
+Pinning is **disabled in debug builds** (empty `BuildConfig` fields) so local development
+works without any certificate setup.
+
+---
+
+## Files involved
+
+| File | Purpose |
+|------|---------|
+| `app/build.gradle` / `app/build.gradle.kts` | `CERT_HOSTNAME`, `CERT_PIN_PRIMARY`, `CERT_PIN_BACKUP` BuildConfig fields |
+| `app/src/main/res/xml/network_security_config.xml` | OS-level pin-set |
+| `app/src/main/java/.../api/SmsApiClient.kt` | OkHttp CertificatePinner wiring |
+
+---
+
+## Local Development (debug builds)
+
+Pinning is **automatically disabled** when `BuildConfig.CERT_HOSTNAME` is blank.  
+No action needed — the app will connect to your local server over plain HTTP.
+
+Default local server URL: `http://10.0.2.2:8080` (Android emulator → host machine)
+
+If you want to test pinning locally against a self-signed HTTPS server:
+
+1. Start your local server with TLS (e.g. via `mkcert` or a self-signed cert).
+2. Extract the pin from the local server:
+   ```bash
+   openssl s_client -connect localhost:8443 -servername localhost </dev/null 2>/dev/null \
+     | openssl x509 -pubkey -noout \
+     | openssl pkey -pubin -outform DER \
+     | openssl dgst -sha256 -binary \
+     | openssl base64
+   ```
+3. In `app/build.gradle`, temporarily update the **debug** block:
+   ```groovy
+   debug {
+       buildConfigField "String", "CERT_HOSTNAME", '"localhost"'
+       buildConfigField "String", "CERT_PIN_PRIMARY", '"sha256/<output-from-step-2>"'
+       buildConfigField "String", "CERT_PIN_BACKUP", '""'
+   }
+   ```
+   > ⚠️ Do **not** commit these local overrides. Revert before pushing.
+
+---
+
+## Staging / Production (release builds)
+
+### Source of truth
+
+All production pin values come from the **server pin bundle**:
+
+```
+DanyalTorabi/sms-syncer-server
+└── docs/security/android-pin-bundle.json
+```
+
+Server handoff issue: [DanyalTorabi/sms-syncer-server#130](https://github.com/DanyalTorabi/sms-syncer-server/issues/130)  
+Rotation runbook: `docs/security/android-certificate-pinning-runbook.md` in the server repo
+
+### Mapping from bundle → Android files
+
+| `android-pin-bundle.json` field | Android target |
+|---------------------------------|---------------|
+| `hosts[].hostname` | `CERT_HOSTNAME` in both `build.gradle` files + `<domain>` in `network_security_config.xml` |
+| `hosts[].pins.current` | `CERT_PIN_PRIMARY` (include the `sha256/` prefix) |
+| `hosts[].pins.backup` | `CERT_PIN_BACKUP` (include the `sha256/` prefix) |
+| `hosts[].validity.notAfter` | `expiration` attribute in `<pin-set>` in `network_security_config.xml` |
+
+### Step-by-step
+
+1. Clone / pull the server repo and open `docs/security/android-pin-bundle.json`.
+2. Copy the values for your target environment (staging or production).
+3. Update **both** `app/build.gradle` and `app/build.gradle.kts` release block:
+   ```groovy
+   buildConfigField "String", "CERT_HOSTNAME",    '"api.yourdomain.com"'
+   buildConfigField "String", "CERT_PIN_PRIMARY", '"sha256/<current-pin>"'
+   buildConfigField "String", "CERT_PIN_BACKUP",  '"sha256/<backup-pin>"'
+   ```
+4. Update `app/src/main/res/xml/network_security_config.xml`:
+   ```xml
+   <domain includeSubdomains="true">api.yourdomain.com</domain>
+   <pin-set expiration="YYYY-MM-DD">
+       <pin digest="SHA-256"><current-pin-without-sha256-prefix></pin>
+       <pin digest="SHA-256"><backup-pin-without-sha256-prefix></pin>
+   </pin-set>
+   ```
+   > Note: `network_security_config.xml` uses the raw base64 value **without** the `sha256/` prefix,
+   > while `BuildConfig` fields include it.
+5. Open a PR referencing the server handoff issue.
+
+---
+
+## Certificate rotation
+
+Follow the runbook in `DanyalTorabi/sms-syncer-server`:
+```
+docs/security/android-certificate-pinning-runbook.md
+```
+
+Key rules:
+- Give **14 days notice** before rotating (notify Android maintainers).
+- Always keep a **backup pin** active before deploying a new certificate.
+- Never remove old pins in the same release as the key rotation.
+- Update `expiration` date in `network_security_config.xml` to match the new cert validity.
+
+---
+
+## Verifying a live endpoint
+
+```bash
+openssl s_client -connect api.yourdomain.com:443 -servername api.yourdomain.com </dev/null 2>/dev/null \
+  | openssl x509 -pubkey -noout \
+  | openssl pkey -pubin -outform DER \
+  | openssl dgst -sha256 -binary \
+  | openssl base64
+```
+
+The output should match `hosts[].pins.current` in the server pin bundle.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| `CertificatePinningException` in logcat | Pin mismatch or cert rotated | Re-extract pin from live endpoint and compare with bundle |
+| App connects fine in debug but fails in release | Release pins not updated | Follow the staging/production steps above |
+| `SSLPeerUnverifiedException` | Same as pin mismatch | Same fix |
+| Sync halted notification shown | `SmsSyncService` caught a pinning failure | Check logcat for `SmsApiClient` tag |
+


### PR DESCRIPTION
## Summary
Implements OkHttp `CertificatePinner` + Android Network Security Config `<pin-set>` for MITM prevention.
## Changes
- `AuthExceptions.kt`: Add `CertificatePinningException` to sealed hierarchy
- `SmsApiClient.kt`: Wire `CertificatePinner` from `BuildConfig` fields; skip gracefully over HTTP or in debug builds
- `AuthRepository.kt`: Catch and propagate `CertificatePinningException` as typed `Result.failure`
- `AuthViewModel.kt`: Map to user-friendly security error message
- `SmsSyncService.kt`: Halt sync and post notification on pinning failure
- `network_security_config.xml`: Add `<pin-set>` for production domain (OS-level defence-in-depth)
- `build.gradle` / `build.gradle.kts`: Add `CERT_HOSTNAME`, `CERT_PIN_PRIMARY`, `CERT_PIN_BACKUP` buildConfigFields; debug=empty (pinning off), release=real pins; enable `buildConfig = true`
## Dev/Prod behaviour
| Build | Pinning |
|-------|---------|
| debug | Disabled (empty BuildConfig fields) |
| release | Enabled via sha256/ pins |
| HTTP URL | Skipped with warning log |
## Certificate rotation
Keep a backup pin active before deploying a new cert to the server. Update both `build.gradle` files and `network_security_config.xml` with the new pins.
## How to extract the pin
```bash
openssl s_client -connect yourdomain.com:443   | openssl x509 -pubkey -noout   | openssl pkey -pubin -outform der   | openssl dgst -sha256 -binary   | openssl enc -base64
```
Closes #56